### PR TITLE
Improve calculation of pairing matrix statistics

### DIFF
--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -21,6 +21,8 @@
 # frozen_string_literal: true
 
 class Session < ApplicationRecord
+  extend T::Sig
+
   belongs_to :team
 
   has_many :participations, dependent: :destroy
@@ -32,5 +34,13 @@ class Session < ApplicationRecord
 
   accepts_nested_attributes_for :participations
 
-  scope :current, ->(days = 14) { where('date >= ?', days.days.ago.beginning_of_day) }
+  scope :current, ->(days = 14) { where('date >= ?', (days - 1).days.ago.beginning_of_day) }
+
+  sig { params(users: T::Array[User]).returns(T::Boolean) }
+  def matching_participants(users)
+    # when using the :participants relation directly bullet goes off for some reason
+    participants = participations.map(&:user)
+
+    users.all? { |participant| participants.include?(participant) }
+  end
 end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -26,28 +26,17 @@ class Team < ApplicationRecord
 
   accepts_nested_attributes_for :memberships, reject_if: :all_blank, allow_destroy: true
 
-  sig { params(users: User).returns(Numeric) }
-  def number_of_sessions_for(*users)
-    sessions.current.filter do |session|
-      users.all? { |participant| session.participations.map(&:user).include?(participant) }
-    end.length
-  end
-
-  sig { params(users: User).returns(T::Boolean) }
-  def paired_today?(*users)
-    sessions.includes(participations: :user).current(1).any? do |session|
-      users.all? do |participant|
-        session.participations.map(&:user).include?(participant)
-      end
-    end
-  end
-
-  sig { params(users: User).returns(Session) }
-  def build_session(*users)
-    session = sessions.build(date: Time.zone.today)
+  sig { params(users: T::Array[User], date: Date).returns(Session) }
+  def build_session(users, date = Time.zone.today)
+    session = sessions.build(date: date)
     users.each do |user|
       session.participations.build(user: user)
     end
     session
+  end
+
+  sig { params(days: Integer).returns(PairingStatistics) }
+  def pairing_statistics(days)
+    PairingStatistics.new(self, days)
   end
 end

--- a/app/services/pairing_statistics.rb
+++ b/app/services/pairing_statistics.rb
@@ -1,0 +1,31 @@
+# typed: strict
+
+# frozen_string_literal: true
+
+class PairingStatistics
+  extend T::Sig
+
+  sig { params(team: Team, days: Integer).void }
+  def initialize(team, days)
+    @team = team
+    @days = days
+    @sessions = T.let(nil, T.nilable(T::Array[Session]))
+  end
+
+  sig { params(users: T::Array[User]).returns(T::Boolean) }
+  def paired?(users)
+    sessions.any? { |session| session.matching_participants(users) }
+  end
+
+  sig { params(users: T::Array[User]).returns(Numeric) }
+  def number_of_sessions_for(users)
+    sessions.filter { |session| session.matching_participants(users) }.length
+  end
+
+  private
+
+  sig { returns(T::Array[Session]) }
+  def sessions
+    @sessions ||= @team.sessions.includes(participations: :user).current(@days).to_a
+  end
+end

--- a/app/views/dashboard/_add_session.html.erb
+++ b/app/views/dashboard/_add_session.html.erb
@@ -1,7 +1,7 @@
 <h5>Add pairing session</h5>
 <% team.members.each do |member| %>
   <% if member != user %>
-    <%= form_for(team.build_session(user, member), html: { class: 'd-inline' }) do |f| %>
+    <%= form_for(team.build_session([user, member]), html: { class: 'd-inline' }) do |f| %>
       <%= f.hidden_field :team_id %>
       <%= f.hidden_field :date %>
       <%= f.fields_for :participations do |p| %>
@@ -9,7 +9,7 @@
         <%= p.hidden_field :user_id %>
         <%= p.hidden_field :session_id %>
       <% end %>
-      <%= f.submit member.name, class: "btn btn-primary", disabled: team.paired_today?(user, member) %>
+      <%= f.submit member.name, class: "btn btn-primary", disabled: statistics.paired?([user, member]) %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/dashboard/_matrix.html.erb
+++ b/app/views/dashboard/_matrix.html.erb
@@ -16,7 +16,7 @@
             <td class="bg-light"></td>
           <% else %>
             <td class="text-center">
-              <%= team.number_of_sessions_for(member, partner) %>
+              <%= statistics.number_of_sessions_for([member, partner]) %>
             </td>
           <% end %>
         <% end %>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -6,9 +6,9 @@
   <div class="card">
     <div class="card-body">
       <h3 class="card-title"><%= team.name %></h3>
-      <%= render "add_session", team: team, user: @user %>
+      <%= render "add_session", team: team, statistics: team.pairing_statistics(1), user: @user %>
       <hr />
-      <%= render "matrix", team: team %>
+      <%= render "matrix", team: team, statistics: team.pairing_statistics(14) %>
     </div>
   </div>
 <% end %>

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -35,4 +35,6 @@ two:
   email: user@example.org
   name: user
 
-# column: value
+three:
+  email: someoneelse@example.org
+  name: someoneelse

--- a/test/models/session_test.rb
+++ b/test/models/session_test.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: false
 # == Schema Information
 #
 # Table name: sessions
@@ -23,7 +23,25 @@
 require 'test_helper'
 
 class SessionTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  def setup
+    @team = teams(:one)
+    @team.memberships.build(user: users(:one))
+    @team.memberships.build(user: users(:two))
+    @team.memberships.build(user: users(:three))
+    @team.save!
+  end
+
+  test 'it finds matching participants' do
+    subject = Session.new(team: @team,
+                          date: Time.zone.today,
+                          participations: [
+                            Participation.new(user: users(:one)),
+                            Participation.new(user: users(:two))
+                          ])
+
+    assert subject.matching_participants([users(:one), users(:two)])
+    assert_not subject.matching_participants([users(:one), users(:three)])
+    assert_not subject.matching_participants([users(:two), users(:three)])
+    assert_not subject.matching_participants([users(:one), users(:two), users(:three)])
+  end
 end

--- a/test/services/pairing_statistics_test.rb
+++ b/test/services/pairing_statistics_test.rb
@@ -1,0 +1,62 @@
+# typed: false
+
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class UserTest < ActiveSupport::TestCase
+  def setup
+    @team = teams(:one)
+    @team.memberships.build(user: users(:one))
+    @team.memberships.build(user: users(:two))
+    @team.memberships.build(user: users(:three))
+    @team.save!
+  end
+
+  test 'it shows there was a pairing for one day' do
+    @team.build_session([users(:one), users(:two)], Time.zone.today).save!
+    @team.build_session([users(:one), users(:two)], Time.zone.today - 1.day).save!
+    @team.build_session([users(:one), users(:three)], Time.zone.today - 1.day).save!
+    subject = PairingStatistics.new(@team, 1)
+
+    assert subject.paired?([users(:one), users(:two)])
+    assert_not subject.paired?([users(:one), users(:three)])
+    assert_not subject.paired?([users(:two), users(:three)])
+  end
+
+  test 'it shows there was a pairing for multiple days' do
+    @team.build_session([users(:one), users(:two)], Time.zone.today).save!
+    @team.build_session([users(:one), users(:two)], Time.zone.today - 1.day).save!
+    @team.build_session([users(:one), users(:three)], Time.zone.today - 1.day).save!
+    subject = PairingStatistics.new(@team, 2)
+
+    assert subject.paired?([users(:one), users(:two)])
+    assert subject.paired?([users(:one), users(:three)])
+    assert_not subject.paired?([users(:two), users(:three)])
+  end
+
+  test 'it gives the correct number of pairing sessions for one day' do
+    @team.build_session([users(:one), users(:two)], Time.zone.today).save!
+    @team.build_session([users(:one), users(:two)], Time.zone.today - 1.day).save!
+    @team.build_session([users(:one), users(:three)], Time.zone.today - 1.day).save!
+    @team.build_session([users(:one), users(:two)], Time.zone.today - 1.day).save!
+    subject = PairingStatistics.new(@team, 1)
+
+    assert_equal 1, subject.number_of_sessions_for([users(:one), users(:two)])
+    assert_equal 0, subject.number_of_sessions_for([users(:one), users(:three)])
+    assert_equal 0, subject.number_of_sessions_for([users(:two), users(:three)])
+  end
+
+  test 'it gives the correct number of pairing sessions for multiple days' do
+    @team.build_session([users(:one), users(:two)], Time.zone.today).save!
+    @team.build_session([users(:one), users(:two)], Time.zone.today - 1.day).save!
+    @team.build_session([users(:one), users(:three)], Time.zone.today - 1.day).save!
+    @team.build_session([users(:one), users(:two)], Time.zone.today - 1.day).save!
+    @team.build_session([users(:one), users(:two)], Time.zone.today - 2.days).save!
+    subject = PairingStatistics.new(@team, 2)
+
+    assert_equal 3, subject.number_of_sessions_for([users(:one), users(:two)])
+    assert_equal 1, subject.number_of_sessions_for([users(:one), users(:three)])
+    assert_equal 0, subject.number_of_sessions_for([users(:two), users(:three)])
+  end
+end


### PR DESCRIPTION
By extracting things related to the statistics into it's own service object
which avoids doing n*m (cached) db queries and instead does one query.

A second query is used to determine if one has already paired with someone else
to disable the buttons above the matrix